### PR TITLE
Change actions/buttons initialization

### DIFF
--- a/orangewidget/tests/test_widget.py
+++ b/orangewidget/tests/test_widget.py
@@ -466,6 +466,15 @@ class WidgetTestInfoSummary(WidgetTest):
         with self.assertRaises(TypeError):
             info.set_output_summary(1234, "a")
 
+    def test_info_no_basic_layout(self):
+        with patch.object(MyWidget, "want_basic_layout", False):
+            w = MyWidget()
+
+        w.info.set_input_summary(w.info.NoInput)
+        inmsg = w.findChild(MessagesWidget, "input-summary")  # type: MessagesWidget
+        self.assertTrue(inmsg.isVisibleTo(w))
+        self.assertEqual(len(inmsg.messages()), 1)
+
     def test_format_number(self):
         self.assertEqual(StateInfo.format_number(9999), "9999")
         self.assertEqual(StateInfo.format_number(12_345), "12.3k")

--- a/orangewidget/utils/buttons.py
+++ b/orangewidget/utils/buttons.py
@@ -70,8 +70,8 @@ class SimpleButton(QAbstractButton):
     A simple icon button widget.
     """
     def __init__(self, parent=None, **kwargs):
-        super().__init__(parent, **kwargs)
         self.__focusframe = None
+        super().__init__(parent, **kwargs)
 
     def focusInEvent(self, event):
         # reimplemented

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -285,7 +285,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
         if self.controlArea is not None:
             # Otherwise, the first control has focus
-            self.controlArea.setFocus(Qt.ActiveWindowFocusReason)
+            self.controlArea.setFocus(Qt.OtherFocusReason)
 
         if self.__splitter is not None:
             self.__splitter.handleClicked.connect(self.__toggleControlArea)

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -197,6 +197,9 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     contextOpened = Signal()
     contextClosed = Signal()
 
+    __report_action = None  # type: Optional[QAction]
+    __save_image_action = None  # type: Optional[QAction]
+    __reset_action = None  # type: Optional[QAction]
     # pylint: disable=protected-access, access-member-before-definition
     def __new__(cls, *args, captionTitle=None, **kwargs):
         self = super().__new__(cls, None, cls.get_flags())
@@ -236,36 +239,56 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         self.__msgwidget = None
         self.__msgchoice = 0
 
+        # this action is enabled by the canvas framework
         self.__help_action = QAction(
             "Help", self, objectName="action-help", toolTip="Show help",
-            enabled=False, visible=False, shortcut=QKeySequence(Qt.Key_F1)
+            enabled=False, visible=False,
+            shortcut=QKeySequence(Qt.Key_F1)
         )
+        if hasattr(self, "send_report"):
+            self.__report_action = QAction(
+                "Report", self, objectName="action-report",
+                toolTip="Create and display a report",
+                shortcut=QKeySequence(Qt.AltModifier | Qt.Key_R))
+            self.__report_action.triggered.connect(self.show_report)
+
+        if self.graph_name is not None:
+            self.__save_image_action = QAction(
+                "Save Image", self, objectName="action-save-image",)
+            self.__save_image_action.triggered.connect(self.save_graph)
+
+        if hasattr(self, "reset_settings"):
+            self.__reset_action = QAction(
+                "Reset", self, objectName="action-reset-settings",
+                toolTip="Reset settings to default state",)
+            self.__reset_action.triggered.connect(self.reset_settings)
+
         self.addAction(self.__help_action)
-        self.__statusbar = None  # type: Optional[QStatusBar]
-        self.__statusbar_action = None  # type: Optional[QAction]
-        self.__info_ns = None  # type: Optional[StateInfo]
+
+        self.__info_ns = None
 
         self.left_side = None
         self.controlArea = self.mainArea = self.buttonsArea = None
-        self.__progressBar = None
+
         self.__splitter = None
         if self.want_basic_layout:
             self.set_basic_layout()
 
-        sc = QShortcut(QKeySequence(Qt.ShiftModifier | Qt.Key_F1), self)
-        sc.activated.connect(self.__quicktip)
+        if self.UserAdviceMessages:
+            sc = QShortcut(QKeySequence(Qt.ShiftModifier | Qt.Key_F1), self)
+            sc.activated.connect(self.__quicktip)
 
-        sc = QShortcut(QKeySequence.Copy, self)
-        sc.activated.connect(self.copy_to_clipboard)
+        if type(self).copy_to_clipboard != OWBaseWidget.copy_to_clipboard \
+                or self.graph_name is not None:
+            sc = QShortcut(QKeySequence.Copy, self)
+            sc.activated.connect(self.copy_to_clipboard)
 
         if self.controlArea is not None:
             # Otherwise, the first control has focus
             self.controlArea.setFocus(Qt.ActiveWindowFocusReason)
 
         if self.__splitter is not None:
-            self.__splitter.handleClicked.connect(
-                self.__toggleControlArea
-            )
+            self.__splitter.handleClicked.connect(self.__toggleControlArea)
             sc = QShortcut(
                 QKeySequence(Qt.ControlModifier | Qt.ShiftModifier | Qt.Key_D),
                 self, autoRepeat=False)
@@ -473,94 +496,13 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             self._insert_main_area()
 
         if self.want_message_bar:
-            sb = self.statusBar()
+            # statusBar() handles 'want_message_bar', 'send_report'
+            # 'graph_name' ...
+            _ = self.statusBar()
 
-            buttonsLayout = QHBoxLayout()
-            buttonsLayout.setContentsMargins(7, 0, 0, 0)
-            buttonsLayout.setSpacing(5)
-
-            help = self.__help_action
-            icon = QIcon(gui.resource_filename("icons/help.svg"))
-            icon.addFile(gui.resource_filename("icons/help-hover.svg"), mode=QIcon.Active)
-            help_button = SimpleButton(
-                icon=icon,
-                toolTip="Show widget help", visible=help.isVisible(),
-            )
-            @help.changed.connect
-            def _():
-                help_button.setVisible(help.isVisible())
-                help_button.setEnabled(help.isEnabled())
-            help_button.clicked.connect(help.trigger)
-            buttonsLayout.addWidget(help_button)
-
-            if self.graph_name is not None:
-                icon = QIcon(gui.resource_filename("icons/chart.svg"))
-                icon.addFile(gui.resource_filename("icons/chart-hover.svg"), mode=QIcon.Active)
-                b = SimpleButton(
-                    icon=icon,
-                    toolTip="Save Image",
-                )
-                b.clicked.connect(self.save_graph)
-                buttonsLayout.addWidget(b)
-            if hasattr(self, "send_report"):
-                icon = QIcon(gui.resource_filename("icons/report.svg"))
-                icon.addFile(gui.resource_filename("icons/report-hover.svg"), mode=QIcon.Active)
-                b = SimpleButton(
-                    icon=icon,
-                    toolTip="Report"
-                )
-                b.clicked.connect(self.show_report)
-                buttonsLayout.addWidget(b)
-            if hasattr(self, "reset_settings"):
-                icon = QIcon(gui.resource_filename("icons/reset.svg"))
-                icon.addFile(gui.resource_filename("icons/reset-hover.svg"), mode=QIcon.Active)
-                b = SimpleButton(
-                    icon=icon,
-                    toolTip="Reset settings to defaults"
-                )
-                b.clicked.connect(self.reset_settings)
-                buttonsLayout.addWidget(b)
-
-            buttons = QWidget(objectName="buttons")
-            buttons.setLayout(buttonsLayout)
-            sb.addWidget(buttons)
-
-            in_out_msg = QWidget(objectName="in-out-msg")
-            in_out_msg.setLayout(QHBoxLayout())
-            in_out_msg.layout().setContentsMargins(5, 0, 0, 0)
-            in_out_msg.layout().setSpacing(5)
-            in_out_msg.setVisible(False)
-            sb.addWidget(in_out_msg)
-
-            self.message_bar = MessagesWidget(
-                defaultStyleSheet=textwrap.dedent("""
-                div.field-text {
-                    white-space: pre;
-                }
-                div.field-detailed-text {
-                    margin-top: 0.5em;
-                    margin-bottom: 0.5em;
-                    margin-left: 1em;
-                    margin-right: 1em;
-                }"""),
-                elideText=True
-            )
-            self.message_bar.setSizePolicy(QSizePolicy.Preferred,
-                                           QSizePolicy.Preferred)
-            self.message_bar.hide()
-            self.__progressBar = pb = QProgressBar(
-                maximumWidth=120, minimum=0, maximum=100
-            )
-            pb.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Ignored)
-            pb.setAttribute(Qt.WA_LayoutUsesWidgetRect)
-            pb.setAttribute(Qt.WA_MacMiniSize)
-            pb.hide()
-            sb.addPermanentWidget(pb)
-            sb.addPermanentWidget(self.message_bar)
-
-            self.processingStateChanged.connect(self.__processingStateChanged)
-            self.blockingStateChanged.connect(self.__processingStateChanged)
-            self.progressBarValueChanged.connect(lambda v: pb.setValue(int(v)))
+    __progressBar = None  # type: Optional[QProgressBar]
+    __statusbar = None    # type: Optional[QStatusBar]
+    __statusbar_action = None  # type: Optional[QAction]
 
     def statusBar(self):
         # type: () -> QStatusBar
@@ -613,8 +555,68 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                 shortcut=QKeySequence(
                     Qt.ShiftModifier | Qt.ControlModifier | Qt.Key_Backslash)
             )
+            if self.want_message_bar:
+                self.message_bar = MessagesWidget(
+                    defaultStyleSheet=(
+                        "div.field-text { white-space: pre; }\n"
+                        "div.field-detailed-text {\n"
+                        "    margin-top: 0.5em; margin-bottom: 0.5em; \n"
+                        "    margin-left: 1em; margin-right: 1em;\n"
+                        "}"
+                    ),
+                    elideText=True,
+                    sizePolicy=QSizePolicy(QSizePolicy.Preferred,
+                                           QSizePolicy.Preferred),
+                    visible=False
+                )
+            self.__progressBar = pb = QProgressBar(
+                maximumWidth=120, minimum=0, maximum=100
+            )
+            pb.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Ignored)
+            pb.setAttribute(Qt.WA_LayoutUsesWidgetRect)
+            pb.setAttribute(Qt.WA_MacMiniSize)
+            pb.hide()
+            self.processingStateChanged.connect(self.__processingStateChanged)
+            self.blockingStateChanged.connect(self.__processingStateChanged)
+            self.progressBarValueChanged.connect(lambda v: pb.setValue(int(v)))
+
+            statusbar.addPermanentWidget(pb)
+            if self.message_bar is not None:
+                statusbar.addPermanentWidget(self.message_bar)
+
             statusbar_action.toggled[bool].connect(statusbar.setVisible)
             self.addAction(statusbar_action)
+
+            # reserve buttons and in_out_msg areas
+            def hlayout(spacing, left=0, right=0, ):
+                lay = QHBoxLayout(spacing=spacing)
+                lay.setContentsMargins(left, 0, right, 0)
+                return lay
+
+            buttons = QWidget(statusbar, objectName="buttons", visible=False)
+            buttons.setLayout(hlayout(5, 7))
+            buttonsLayout = buttons.layout()
+            simple_button, icon = _StatusBar.simple_button, _StatusBar.icon
+            if self.__help_action is not None:
+                b = simple_button(buttons, self.__help_action, icon("help"))
+                buttonsLayout.addWidget(b)
+            if self.__save_image_action is not None:
+                b = simple_button(buttons, self.__save_image_action, icon("chart"))
+                buttonsLayout.addWidget(b)
+            if self.__report_action is not None:
+                b = simple_button(buttons, self.__report_action, icon("report"))
+                buttonsLayout.addWidget(b)
+            if self.__reset_action is not None:
+                b = simple_button(buttons, self.__reset_action, icon("reset"))
+                buttonsLayout.addWidget(b)
+
+            if buttonsLayout.count():
+                buttons.setVisible(True)
+
+            in_out_msg = QWidget(objectName="in-out-msg", visible=False)
+            in_out_msg.setLayout(hlayout(5, left=5))
+            statusbar.addWidget(buttons)
+            statusbar.addWidget(in_out_msg)
         return statusbar
 
     def __updateStatusBarOnChange(self):
@@ -640,6 +642,8 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         elif self.processingState:
             pb.setRange(0, 100)  # determinate pb
 
+    __info_ns = None  # type: Optional[StateInfo]
+
     def __info(self):
         # Create and return the StateInfo object
         if self.__info_ns is None:
@@ -659,6 +663,9 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
             sb = self.statusBar()
             if sb is not None:
+                in_out_msg = sb.findChild(QWidget, "in-out-msg")
+                assert in_out_msg is not None
+                in_out_msg.setVisible(True)
                 in_msg = MessagesWidget(
                     objectName="input-summary", visible=False,
                     defaultStyleSheet=css,
@@ -672,10 +679,9 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                                            QSizePolicy.Fixed)
                 )
 
-                in_out_msg = sb.findChild(QWidget, "in-out-msg")
-
                 # Insert a separator if these are not the first elements
                 buttons = sb.findChild(QWidget, "buttons")
+                assert buttons is not None
                 if buttons.layout().count() != 0:
                     sep = QFrame(frameShape=QFrame.VLine)
                     sep.setContentsMargins(0, 0, 2, 0)
@@ -1383,6 +1389,35 @@ class _StatusBar(QStatusBar):
         style.drawPrimitive(QStyle.PE_PanelStatusBar, opt, painter, None)
         # Do not draw any PE_FrameStatusBarItem frames.
         painter.end()
+
+    @staticmethod
+    def simple_button(
+            parent: QWidget, action: QAction, icon=QIcon()
+    ) -> SimpleButton:
+        if icon.isNull():
+            icon = action.icon()
+        button = SimpleButton(
+            parent,
+            icon=icon,
+            toolTip=action.toolTip(), whatsThis=action.whatsThis(),
+            visible=action.isVisible(), enabled=action.isEnabled(), )
+
+        def update():
+            button.setVisible(action.isVisible())
+            button.setEnabled(action.isEnabled())
+            button.setToolTip(action.toolTip())
+            button.setWhatsThis(action.whatsThis())
+
+        action.changed.connect(update)
+        button.clicked.connect(action.triggered)
+        return button
+
+    @staticmethod
+    def icon(name):
+        icon = QIcon(gui.resource_filename("icons/{}.svg".format(name)))
+        icon.addFile(gui.resource_filename("icons/{}-hover.svg".format(name)),
+                     mode=QIcon.Active)
+        return icon
 
 
 class Message:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes

Move the status bar buttons init out of the `want_message_bar` block. Actions are created instead and bound in `statusBar` constructor if applicable.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
